### PR TITLE
Fixed division by zero

### DIFF
--- a/decipy/normalizers.py
+++ b/decipy/normalizers.py
@@ -76,11 +76,13 @@ class Vector(NormalizerBase):
             if self.beneficial[c]:
                 # Benefit Criteria
                 denom = np.power(self.xij[c], 2)
-                self.rij[c] = self.xij[c] / np.sqrt(np.sum(denom))
+                sumd = np.sum(denom)
+                self.rij[c] = 0 if sumd == 0 else self.xij[c] / np.sqrt(sumd)
             else:
                 # Cost Criteria
                 denom = 1 / (np.power(self.xij[c], 2))
-                self.rij[c] = (1 / self.xij[c]) / np.sqrt(np.sum(denom))
+                sumd = np.sum(denom)
+                self.rij[c] = 0 if sumd == 0 else (1 / self.xij[c]) / np.sqrt(sumd)
         return self.rij.transpose()
 
 
@@ -127,12 +129,12 @@ class MinMax(NormalizerBase):
                 # Benefit Criteria
                 nomin = self.xij[c] - np.min(self.xij[c])
                 denom = np.max(self.xij[c]) - np.min(self.xij[c])
-                self.rij[c] = (nomin / denom)
+                self.rij[c] = 0 if denom == 0 else (nomin / denom)
             else:
                 # Cost Criteria
                 nomin = (np.max(self.xij[c]) - self.xij[c])
                 denom = (np.max(self.xij[c]) - np.min(self.xij[c]))
-                self.rij[c] = (nomin / denom)
+                self.rij[c] = 0 if denom == 0 else (nomin / denom)
         return self.rij.transpose()
 
 

--- a/decipy/weigtings.py
+++ b/decipy/weigtings.py
@@ -39,5 +39,5 @@ class MinMax(Weight):
         for i in range(len(self.weights)):
             nomin = np.max(self.rij[i]) - self.rij[i]
             denom = np.max(self.rij[i]) - np.min(self.rij[i])
-            self.vij[i] = self.weights[i] * (nomin / denom)
+            self.vij[i] = 0 if denom == 0 else self.weights[i] * (nomin / denom)
         return self.vij


### PR DESCRIPTION
When we have an array of alternatives as follows:

```
[
  [0, 1, 0]
  [0, 0, 1]
  [0, 1, 1]
]
```

All the alternatives have the value for criterion 1 set to 0. 
This creates `NaN`s when normalizing criteria and scores when applying `TOPSIS`, `VIKOR` and `WSM`.

This pull requests fixes those divisions by zero.